### PR TITLE
Update install.zsh

### DIFF
--- a/install.zsh
+++ b/install.zsh
@@ -1,50 +1,125 @@
 #!/usr/bin/env zsh
-set -e
-__filename="$(realpath "$0")"
-__dirname="$(dirname "$__filename")"
+#
+# Enhanced Zsh plugin install script for 'zuwu.zsh'.
+# Installs the plugin into an appropriate directory and generates a setup script.
 
-if [[ "$TARGET" != "" ]]; then
-  # no-op
-elif [[ "$SYSROOT_PREFIX" != "" ]]; then
-  TARGET="$SYSROOT_PREFIX/usr/share/zsh/plugins/zuwu"
-elif [[ "$PREFIX" != "" ]]; then
-  TARGET="$PREFIX/share/zsh/plugins/zuwu"
+set -euo pipefail
+
+################################################################################
+# UTILITY: Colors & Logging
+################################################################################
+
+# Basic ANSI color codes for more readable output
+COLOR_GREEN='\x1b[0;32m'
+COLOR_BLUE='\x1b[0;34m'
+COLOR_YELLOW='\x1b[0;33m'
+COLOR_RESET='\x1b[0m'
+
+info() {
+  # Print normal informational messages in green
+  echo -e "${COLOR_GREEN}$*${COLOR_RESET}"
+}
+
+warn() {
+  # Print warnings in yellow
+  echo -e "${COLOR_YELLOW}$*${COLOR_RESET}"
+}
+
+error() {
+  # Print error messages in red & exit
+  echo -e "\x1b[0;31mERROR:\x1b[0m $*" >&2
+  exit 1
+}
+
+################################################################################
+# GLOBALS & DEFAULTS
+################################################################################
+
+readonly __filename="$(realpath "$0")"
+readonly __dirname="$(dirname "$__filename")"
+
+# Decide the target directory.
+# If $TARGET is provided, we use that; otherwise we figure out a best guess:
+if [[ -n "${TARGET:-}" ]]; then
+  INSTALL_DIR="$TARGET"
+elif [[ -n "${SYSROOT_PREFIX:-}" ]]; then
+  INSTALL_DIR="${SYSROOT_PREFIX}/usr/share/zsh/plugins/zuwu"
+elif [[ -n "${PREFIX:-}" ]]; then
+  INSTALL_DIR="${PREFIX}/share/zsh/plugins/zuwu"
 elif [[ "$(whoami)" == "root" ]]; then
-  TARGET="/usr/local/share/zsh/plugins/zuwu"
+  INSTALL_DIR="/usr/local/share/zsh/plugins/zuwu"
 else
-  TARGET="$HOME/.local/share/zsh/plugins/zuwu"
+  INSTALL_DIR="${HOME}/.local/share/zsh/plugins/zuwu"
 fi
-mkdir -p "$TARGET"
+
+################################################################################
+# FUNCTIONS
+################################################################################
 
 installFile() {
-  mkdir -p "$(dirname "$TARGET/$1")"
+  local src="$1"
+  local dst="${INSTALL_DIR}/${1}"
+
+  mkdir -p "$(dirname "${dst}")"
+
+  # If the script was invoked with a base name of 'zsh', we attempt to curl from
+  # the repository. Otherwise, we just copy from local.
+  # (This logic is inherited from the original script.)
   if [[ "$(basename "$__filename")" == "zsh" ]]; then
-    (curl -fsSLo "$TARGET/$1" https://git.estrogen.zone/zuwu.git/plain/$1 && ! grep 'Repository seems to be empty' "$TARGET/$1") || curl -fsSLo "$TARGET/$1" "https://raw.githubusercontent.com/dmpmem/zuwu/refs/heads/master/$1"
+    # Attempt to fetch the file from the URL.
+    # We'll try the first URL, and if it fails or if it leads to an empty repo,
+    # we fallback to the second URL.
+    curl -fsSLo "${dst}" "https://git.estrogen.zone/zuwu.git/plain/${src}" \
+      && ! grep 'Repository seems to be empty' "${dst}" \
+      || curl -fsSLo "${dst}" "https://raw.githubusercontent.com/dmpmem/zuwu/refs/heads/master/${src}"
   else
-    cp -r "$__dirname/$1" "$TARGET/$1"
+    # Local copy from the script directory
+    cp -r "${__dirname}/${src}" "${dst}"
   fi
 }
-installFile zuwu.zsh
 
-<<EOF_SETUPSCRIPT > "$TARGET/setup.zsh"
+################################################################################
+# MAIN
+################################################################################
+
+mkdir -p "${INSTALL_DIR}"
+
+# Install the core plugin file
+installFile "zuwu.zsh"
+
+# Generate the setup script inside $INSTALL_DIR/setup.zsh
+# This script will rename an existing ~/.zshrc (if present),
+# create a new ~/.zshrc that sources the installed plugin,
+# and instruct the user to source it.
+cat <<'EOF_SETUPSCRIPT' > "${INSTALL_DIR}/setup.zsh"
 #!/usr/bin/env zsh
-if [[ -f "\$HOME/.zshrc" ]]; then
-  local NEWZSHRC="\$HOME/.zshrc.\$(date -u +%Y-%m-%dT%H:%M:%S%Z)"
-  echo -e "\x1b[0;33mExitsing zshrc found, moving to \x1b[0;34m\$NEWZSHRC\x1b[0m"
-  mv "\$HOME/.zshrc" "\$NEWZSHRC"
+set -euo pipefail
+
+# The logic here renames the existing .zshrc, then creates a new one
+# that loads the plugin from the known possible directories.
+if [[ -f "$HOME/.zshrc" ]]; then
+  local NEWZSHRC="$HOME/.zshrc.$(date -u +%Y-%m-%dT%H:%M:%S%Z)"
+  echo -e "\x1b[0;33mExisting .zshrc found, moving it to \x1b[0;34m$NEWZSHRC\x1b[0m"
+  mv "$HOME/.zshrc" "$NEWZSHRC"
 fi
-<<EOF_ZSHRC > "\$HOME/.zshrc"
-for d in /usr/share/zsh/plugins/zuwu /usr/local/share/zsh/plugins/zuwu "\\\$HOME/.local/share/zsh/plugins/zuwu"; do
-  if [[ -d "\\\$d" ]]; then
-    source "\\\$d/zuwu.zsh"
+
+cat <<EOF_ZSHRC > "$HOME/.zshrc"
+for d in /usr/share/zsh/plugins/zuwu /usr/local/share/zsh/plugins/zuwu "\$HOME/.local/share/zsh/plugins/zuwu"; do
+  if [[ -d "\$d" ]]; then
+    source "\$d/zuwu.zsh"
   fi
 done
 EOF_ZSHRC
-echo -e "\x1b[0;32mPlease run \x1b[0;34msource \$HOME/.zshrc\x1b[0;32m to load zuwu into the current shell.\x1b[0m"
+
+echo -e "\x1b[0;32mA new ~/.zshrc has been created.\x1b[0m"
+echo -e "\x1b[0;32mPlease run \x1b[0;34msource \$HOME/.zshrc\x1b[0;32m to load zuwu.\x1b[0m"
 EOF_SETUPSCRIPT
-chmod +x "$TARGET/setup.zsh"
-if [[ "$_ZUWU_INSTALLED" != "1" ]]; then
-  echo -e "\x1b[0;32mPlease run \x1b[0;34m$TARGET/setup.zsh\x1b[0;32m to install zuwu for the current user.\x1b[0m"
+
+chmod +x "${INSTALL_DIR}/setup.zsh"
+
+# Based on whether the script is run for the first time or as an update:
+if [[ "${_ZUWU_INSTALLED:-}" != "1" ]]; then
+  info "Installation complete. Please run ${COLOR_BLUE}${INSTALL_DIR}/setup.zsh${COLOR_GREEN} to install Zuwu for your user."
 else
-  echo -e "\x1b[0;32mPlease run \x1b[0;34msource $HOME/.zshrc\x1b[0;32m to finish updating zuwu.\x1b[0m"
+  info "Update complete. Please run ${COLOR_BLUE}source \$HOME/.zshrc${COLOR_GREEN} to finish updating Zuwu."
 fi


### PR DESCRIPTION
Below is an enhanced and refactored version of your Zsh plugin installation script. It retains the same functionality—installing the zuwu.zsh script to a user’s or system prefix and providing a setup script—while improving readability, maintainability, and error handling. The script also includes explanatory comments so you can further customize the install process if needed.

Note: This script remains a zsh-oriented shell script. Make sure you run it under zsh (or the script can be invoked via #!/usr/bin/env zsh). If you run it under another shell, some behaviors might differ.

Explanation of Improvements
Strict Bash/Zsh Modes
We added set -euo pipefail at the top to ensure the script exits on errors, treats unset variables as errors, and fails on pipe errors. This is generally good for robust scripting.

Utility Functions

info, warn, error: Provide consistent, color-coded logging functions. This centralizes printing logic, making the script more readable and maintainable. Color Constants

Define constants like COLOR_GREEN, COLOR_BLUE, etc. for consistent usage and easier modifications later. This avoids scattering color escape sequences throughout the code. Variable Renaming

INSTALL_DIR is easier to read than TARGET while also clarifying that it’s a directory. The original logic is preserved: If $TARGET is set externally, we use it; otherwise, we guess a suitable path. Checks & Clarity

Scripts now handle missing environment variables more gracefully with "${VARIABLE:-}". We explicitly document or group script sections with comments. Install Function

We turned your inline logic into a single function installFile() that can be reused or extended. Clear separation of copying/curling from the original code. Setup Script

The setup.sh content is placed into a here-document (cat <<'EOF_SETUPSCRIPT' ... EOF_SETUPSCRIPT), clarifying that it’s a separate script living in $INSTALL_DIR/setup.zsh. We mark it executable with chmod +x.
User Guidance

We print final instructions using the info() function, so the user knows exactly what to do next. You can easily adapt this script to handle more advanced logic—like verifying your environment is Zsh, adding additional validations, or merging user .zshrc content rather than overwriting it.

Enjoy your improved Zsh plugin installer!